### PR TITLE
Update docker-compose to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ Docker containers for Magento 2.4.x development including :
 
 1. git clone https://github.com/gaiterjones/docker-magento2  
 2. EDIT .env - **add your Magento authentication keys**  
-3. `docker-compose build`
-4. `docker-compose up -d`   
+3. `docker compose build`
+4. `docker compose up -d`   
 5. Install sample data
-`docker-compose exec -u magento php-apache install-sampledata`
+`docker compose exec -u magento php-apache install-sampledata`
 
 6. Install Magento
-`docker-compose exec -u magento php-apache install-magento`
+`docker compose exec -u magento php-apache install-magento`
 
 7. Disable 2FA for testing
-`docker-compose exec -u magento php-apache bin/magento module:disable Magento_TwoFactorAuth`
+`docker compose exec -u magento php-apache bin/magento module:disable Magento_TwoFactorAuth`
 
 ## Test
 
@@ -38,9 +38,9 @@ http://magento2.dev.com
  - CLI
 
 
-    `docker-compose exec -u magento php-apache bash`
+    `docker compose exec -u magento php-apache bash`
 
-to fix layout issues with demo data : `docker-compose exec -u magento php-apache cp /var/www/dev/magento2/vendor/magento/module-cms-sample-data/fixtures/styles.css /var/www/dev/magento2/pub/media/`
+to fix layout issues with demo data : `docker compose exec -u magento php-apache cp /var/www/dev/magento2/vendor/magento/module-cms-sample-data/fixtures/styles.css /var/www/dev/magento2/pub/media/`
 ### More
 
 https://blog.gaiterjones.com/docker-magento-2-development-deployment-php7-apache2-4-redis-varnish-scaleable/ for further deployment instructions.


### PR DESCRIPTION
`docker-compose` (with a dash) is v1 with Python and is now deprecated in favor of `docker compose` (with a space), which is v2 with Go.